### PR TITLE
useFetch hook for better fetch control

### DIFF
--- a/components/useFetch.js
+++ b/components/useFetch.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+export const useFetch = (url) => {
+    const [loading, setLoading] = useState(true)
+    const [data, setData] = useState()
+    const [error, setError] = useState()
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setLoading(true)
+        fetch(url, {signal: controller.signal})
+            .then(setData)
+            .catch(setError)
+            .finally(() => setLoading(false))
+
+        return () => {
+            controller.abort()
+        }
+
+    }, [ulr])
+
+    return {loading, data, error}
+}


### PR DESCRIPTION
## Describe the change
The useFetch hook makes sure only one fetch call is being processed at a time, 
so data is never outdated because of a previous call that took longer to return than a newer one.



